### PR TITLE
イベント一覧ページの改善

### DIFF
--- a/src/events.njk
+++ b/src/events.njk
@@ -11,6 +11,16 @@ title: イベント一覧
     {%- set absolutePostUrl = post.url | absoluteUrl(metadata.url) %}
     <article>
       <h1>{{ post.data.name }}</h1>
+      <p>{{ post.data.summary }}</p>
+      <p>
+        <time datetime="{{ post.data.dtstart }}">
+            {{ post.data.dtstart }}
+        </time>
+        〜
+        <time datetime="{{ post.data.dtend }}">
+            {{ post.data.dtend }}
+        </time>
+      </p>
       <a href="{{ absolutePostUrl }}">詳細</a>
     </article>
   {%- endfor %}

--- a/src/events.njk
+++ b/src/events.njk
@@ -6,7 +6,7 @@ title: イベント一覧
 <article>
   <h1>イベント一覧</h1>
   <p>feedとして購読する場合は、<a href="{{ "/feed.xml" | htmlBaseUrl }}" rel="alternative" type="application/atom+xml">こちら</a>から。</p>
-  <p>カレンダーとして購読したい方は、<a href="{{ ./events.ics | htmlBaseUrl }}" type="text/calendar">こちら</a>からiCalendar形式でも利用できます。</p>
+  <p>カレンダーとして購読したい方は、<a href="{{ "/events.ics" | htmlBaseUrl }}" type="text/calendar">こちら</a>からiCalendar形式でも利用できます。</p>
   {%- for post in collections.event | reverse %}
     {%- set absolutePostUrl = post.url | absoluteUrl(metadata.url) %}
     <article>


### PR DESCRIPTION
- icalendarファイルへのリンクを正しいものへ修正
- イベント一覧ページに開催時刻、summaryを掲載するように