### PR TITLE
`feed.xml`にイベントのタイトルが反映されるようにした

### DIFF
--- a/src/feed.njk
+++ b/src/feed.njk
@@ -27,7 +27,7 @@
   {%- for post in collections.event | reverse %}
   {%- set absolutePostUrl = post.url | absoluteUrl(metadata.url) %}
   <entry>
-    <title>{{ post.data.name }}</title>
+    <title>{{ post.data.title }}</title>
     <link href="{{ absolutePostUrl }}"/>
     <updated>{{ post.date | dateToRfc3339 }}</updated>
     <id>{{ absolutePostUrl }}</id>


### PR DESCRIPTION
現状の`feed.xml`であると、タイトルが正しく表示されない。

```rss
<entry>
<title/>
<link href="https://until-tsukuba.github.io/events/2023/until-lt0x02/"/>
<updated>2023-12-05T12:24:33Z</updated>
<id>
https://until-tsukuba.github.io/events/2023/until-lt0x02/
</id>
<content xml:lang="ja" type="html">
<p>筑波大学に関する情報系技術者によるLT会の第0x02回です。</p> <p>前回0x01回では、ネットワークからマイナープログラミング言語の紹介まで、飛び込みLT枠では、コンピュータやネットワークの話題に留まらず、筑波山の地質や犯罪係数の高い飯テロ画像の作り方まで、幅広い発表がありました。</p> <p>さて、今回は新学期ということもあり、新入生も楽しめるように、テーマは「〜はいいぞ！」とします。みなさんの好きなものを5分、または10分で布教してください。</p> <p>登壇を希望する人は5月20日までに<a href="https://forms.gle/opZwooU2u8hkzQHP8">このGoogle Form</a>に名前、テーマ、希望する枠を記載して提出してください。 飛び込みLT枠を除き、原則、情報技術に絡めた登壇スライドの作成をお願いします。</p> <p>観覧を希望する人は、事前の登録は不要です。当日そのまま会場へお越しください。</p> <p>ハッシュタグは<code>#until_lt0x02</code>です。登壇テーマを提出した際や、当日の実況などに積極的に使ってください！</p> <p>詳細は<a href="https://until-tsukuba.connpass.com/event/281971/">connpassページ</a>をお読みください。</p> <h2>発表テーマ</h2> <h3>10分枠</h3> <p>今回10分枠での発表応募はありませんでした。</p> <h3>5分枠</h3> <p>順番は当日会場でのあみだくじにて決定します。</p> <ul> <li>いなにわうどん「<a href="https://speakerdeck.com/inaniwaudon/until-0601-2">フロントエンドと複雑GUIの話（仮）</a>」</li> <li>A+つくば運営チーム「<a href="https://speakerdeck.com/halfblue/timukai-fa-haiizo-a-plus-tukubashao-jie-until-lt-number-0x02">チーム開発はいいゾ！　～A+つくば紹介～</a>」</li> <li>ちゅるり「<a href="https://speakerdeck.com/chururi/anatatokotlin-jin-suguhazimeyou-until-dot-lt-number-0x02">あなたとKotlin, 今すぐはじめよう</a>」</li> <li>てぃあ「（仮）履歴書は手書きがおすすめ」</li> <li>Arata「ソースコードリーディングはいいぞ」</li> </ul> <h3>飛び込み枠</h3> <ul> <li>青木「ハッカソンのすすめ」</li> <li>onokatio_「目指せ変態エンジニア！～ショートコーディングはいいぞ～」</li> </ul>
</content>
</entry>
```

これは`src/feed.njk`において参照する引数を誤っていたためであるため修正した。