### PR TITLE
feat: summaryを削除

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@
     "dtstart": "{{イベント開始時間}}",
     "dtend": "{{イベント終了時間}}",
     "location": "`{{場所}}",
+    "summary": "{{概要}}"
     "ogp_type": "article"
 }
 ---

--- a/README.md
+++ b/README.md
@@ -23,7 +23,6 @@
     "dtstart": "{{イベント開始時間}}",
     "dtend": "{{イベント終了時間}}",
     "location": "`{{場所}}",
-    "summary": "{{概要}}",
     "ogp_type": "article"
 }
 ---

--- a/README.md
+++ b/README.md
@@ -23,7 +23,8 @@
     "dtstart": "{{イベント開始時間}}",
     "dtend": "{{イベント終了時間}}",
     "location": "`{{場所}}",
-    "summary": "{{概要}}"
+    "summary": "{{概要}}",
+
     "ogp_type": "article"
 }
 ---

--- a/src/_includes/event.njk
+++ b/src/_includes/event.njk
@@ -16,9 +16,6 @@
             場所:
             <span class="p-location" itemprop="location">{{ location }}</span>
         </p>
-        <p class="p-summary">
-            {{ summary }}
-        </p>
     </aside>
     <div class="p-description e-content">
         {{ content | safe }}


### PR DESCRIPTION
> 筑波大学に関する情報技術者によるLT会 第0x03回
> 筑波大学に関する情報技術者によるLT会の第0x03回、今回は[学生LT](https://student-lt.tech/)との共同開催です。
https://until-tsukuba.github.io/events/2023/until-lt0x03/

みたいな表現が重なるのがおかしいのでsummaryがイベント詳細ページに反映されないようにした