### PR TITLE
最低限のSitemapを生成するファイルを追加

### DIFF
--- a/src/sitemap.njk
+++ b/src/sitemap.njk
@@ -1,0 +1,18 @@
+---json
+{
+  "permalink": "sitemap.xml",
+  "eleventyExcludeFromCollections": true,
+  "metadata": {
+    "url": "https://until.tsukuba.dev"
+  }
+}
+---
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  {%- for page in collections.all %}
+    {%- set absolutePageUrl = page.url | absoluteUrl(metadata.url) %}
+    <url>
+      <loc>{{ absolutePageUrl }}</loc>
+    </url>
+  {%- endfor %}
+</urlset>


### PR DESCRIPTION
Close #19 

仕様上最低限必要とされている`<loc>`要素のみを出力するサイトマップを生成するNunjucksファイルを、`feed.njk`を参考に作成しました