### PR TITLE
chore: CSSフレームワークを`chota`から`new.css`に変更した

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -13,7 +13,7 @@ export default (eleventyConfig) => {
     }
   });
   eleventyConfig.addPassthroughCopy({
-    "./node_modules/chota/dist/chota.min.css" : "/assets/css/chota.min.css"
+    "./node_modules/@exampledev/new.css/new.css" : "/assets/css/new.css"
   })
   eleventyConfig.addNunjucksFilter("getNewestCollectionItemDate", pluginRss.getNewestCollectionItemDate)
   eleventyConfig.addNunjucksFilter("dateToRfc3339", pluginRss.dateToRfc3339)

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
             "devDependencies": {
                 "@11ty/eleventy": "^3.0.0",
                 "@11ty/eleventy-plugin-rss": "^1.2.0",
-                "chota": "^0.9.2"
+                "@exampledev/new.css": "^1.1.3"
             }
         },
         "node_modules/@11ty/dependency-tree": {
@@ -279,6 +279,13 @@
                 "rimraf": "^5.0.7",
                 "slash": "^1.0.0"
             }
+        },
+        "node_modules/@exampledev/new.css": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/@exampledev/new.css/-/new.css-1.1.3.tgz",
+            "integrity": "sha512-qhbGfqBRwUlM6MCSaJdUfjq86opNCMvM+6kVvs6S0kYhy0V8dKbe4rDMIklEJGuMc5QH5OuPjdCReu9I0tim2w==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/@isaacs/cliui": {
             "version": "8.0.2",
@@ -627,12 +634,6 @@
             "optionalDependencies": {
                 "fsevents": "~2.3.2"
             }
-        },
-        "node_modules/chota": {
-            "version": "0.9.2",
-            "resolved": "https://registry.npmjs.org/chota/-/chota-0.9.2.tgz",
-            "integrity": "sha512-DmCHT/R+yMr/aYQuokkJeNIjknSgpMpM9mR0tDlqPu8A+lGo9TS/KFPpze5Q9PPrCWenp/VG7Y10usyNDoIygQ==",
-            "dev": true
         },
         "node_modules/color-convert": {
             "version": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,6 @@
     "devDependencies": {
         "@11ty/eleventy": "^3.0.0",
         "@11ty/eleventy-plugin-rss": "^1.2.0",
-        "chota": "^0.9.2"
+        "@exampledev/new.css": "^1.1.3"
     }
 }

--- a/src/_includes/components/navbar.njk
+++ b/src/_includes/components/navbar.njk
@@ -1,9 +1,9 @@
 <nav>
   <div class="tabs">
-    <a href='{{ "/" | htmlBaseUrl }}'>Home</a>
-    <a href='{{ "/events" | htmlBaseUrl }}'>イベント一覧</a>
-    <a rel="me" href="https://twitter.com/until_tsukuba">Twitter</a>
-    <a rel="me" href="https://mi.tsukuba.dev/@until">Misskey (Fediverse)</a>
+    <a href='{{ "/" | htmlBaseUrl }}'>Home</a> /
+    <a href='{{ "/events" | htmlBaseUrl }}'>イベント一覧</a> /
+    <a rel="me" href="https://twitter.com/until_tsukuba">Twitter</a> /
+    <a rel="me" href="https://mi.tsukuba.dev/@until">Misskey (Fediverse)</a> /
     <a rel="me" href="https://github.com/until-tsukuba">GitHub</a>
   </div>
 </nav>

--- a/src/_includes/page.njk
+++ b/src/_includes/page.njk
@@ -4,7 +4,7 @@
   <meta charset="UTF-8"/>
   <link rel="icon" size="32x32" href="{{ "/assets/img/favicon.ico" | htmlBaseUrl }}"/>
   <link rel="stylesheet" href='{{ "/assets/css/custom.css" | htmlBaseUrl }}'>
-  <link rel="stylesheet" href='{{ "/assets/css/chota.min.css" | htmlBaseUrl }}'>
+  <link rel="stylesheet" href='{{ "/assets/css/new.css" | htmlBaseUrl }}'>
   <meta name="generator" content="{{ eleventy.generator }}" />
   <title>
     {% block title %}{{ title }}{% endblock %} - UNTIL.
@@ -12,6 +12,7 @@
   {% include "components/ogp.njk" %}
   {% block head %}
   {% endblock %}
+  <link rel="alternate" type="application/atom+xml" href="{{ "/feed.xml" | htmlBaseUrl }}" title="UNTIL.イベント開催情報" />
   <meta name="google-site-verification" content="3H7Dhs52_3f1pJtfVa3WPn17qiPcvBhB5Mrrh5TwYFc" />
 </head>
 <body>

--- a/src/assets/css/custom.css
+++ b/src/assets/css/custom.css
@@ -1,3 +1,5 @@
 body{
-    margin: 0 1em 0 !important; 
+    margin: 0 auto !important;
+    max-width: 1200px;
+    padding: 0 1em;
 }


### PR DESCRIPTION
[new.css](https://newcss.net/)、class-lessなCSSフレームワークの中で軽量かつシンプルで、見た目もそれなりに良さそうだったのでchota（ #14 ）から切り替えたものを作成してみました。

オリジナルのnew.cssに若干`custom.css`で変更を加えており、センタリングを追加しています。